### PR TITLE
Update dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,21 +16,21 @@
   "devDependencies": {
     "web-component-tester": "^5.0.0",
     "iron-component-page": "^1.1.7",
-    "d2l-demo-template": "^0.0.3",
-    "d2l-icons": "^2.13.0",
-    "d2l-image-action": "^0.5.3",
+    "d2l-demo-template": "^0.0.9",
+    "d2l-icons": "^2.16.1",
+    "d2l-image-action": "^0.6.3",
     "polyperf": "https://github.com/Brightspace/polyperf.git"
   },
   "dependencies": {
-    "d2l-button": "^3.0.6",
-    "d2l-menu": "^0.2.3",
+    "d2l-button": "^3.0.8",
+    "d2l-menu": "^0.2.8",
     "polymer": "^1.7.0",
-    "d2l-dropdown": "^3.0.0",
+    "d2l-dropdown": "^4.0.0",
     "iron-resizable-behavior": "^1.0.5",
     "app-localize-behavior": "https://github.com/Brightspace/app-localize-behavior.git#master",
-    "d2l-offscreen": "^2.1.0"
+    "d2l-offscreen": "^2.2.2"
   },
   "resolutions": {
-    "d2l-typography": "^5.0.0"
+    "d2l-typography": "^5.2.2"
   }
 }


### PR DESCRIPTION
Attempting to update the button-group deps to match the latest, specifically because the d2l-dropdown version needs to be 4.0.0 so that the d2l-my-courses can be updated.