### PR TITLE
Changing when menu select event is fired per button

### DIFF
--- a/d2l-responsive-button-list-behavior.html
+++ b/d2l-responsive-button-list-behavior.html
@@ -60,30 +60,17 @@ behaviors: [D2L.PolymerBehaviors.ButtonGroup.ResponsiveButtonListBehavior]
 			});
 		},
 
-		_onTapItem: function(e) {
-			var button = Polymer.dom(e).localTarget;
-			if (
-				Polymer.dom(button).parentNode === this._listElement &&
-				button.tagName && button.tagName.toLowerCase() === 'button'
-			) {
-				this.fire('d2l-responsive-button-list-select', {
-					src: button
-				});
-			}
-		},
-
 		_onSelectItem: function(e) {
 			if (typeof e.detail.index === 'number') {
 				var index = e.detail.index;
 				var button = this._listNodes[index];
 				if (button) {
-					button.click();
+					var evt = document.createEvent('HTMLEvents');
+					evt.initEvent('d2l-responsive-button-list-menu-select', true, false);
+					button.dispatchEvent(evt);
 					return;
 				}
 			}
-			this.fire('d2l-responsive-button-list-select', {
-				src: e.detail.menuItem || e.target
-			});
 		},
 
 		chomp: function() {

--- a/d2l-responsive-button-list-behavior.html
+++ b/d2l-responsive-button-list-behavior.html
@@ -65,7 +65,7 @@ behaviors: [D2L.PolymerBehaviors.ButtonGroup.ResponsiveButtonListBehavior]
 				var index = e.detail.index;
 				var button = this._listNodes[index];
 				if (button) {
-					button.dispatchEvent(new CustomEvent('d2l-responsive-button-list-menu-select'));
+					button.dispatchEvent(new CustomEvent('d2l-button-ghost-click'));
 					return;
 				}
 			}

--- a/d2l-responsive-button-list-behavior.html
+++ b/d2l-responsive-button-list-behavior.html
@@ -65,9 +65,7 @@ behaviors: [D2L.PolymerBehaviors.ButtonGroup.ResponsiveButtonListBehavior]
 				var index = e.detail.index;
 				var button = this._listNodes[index];
 				if (button) {
-					var evt = document.createEvent('HTMLEvents');
-					evt.initEvent('d2l-responsive-button-list-menu-select', true, false);
-					button.dispatchEvent(evt);
+					button.dispatchEvent(new CustomEvent('d2l-responsive-button-list-menu-select'));
 					return;
 				}
 			}

--- a/test/button-group.html
+++ b/test/button-group.html
@@ -261,20 +261,10 @@
 
 				testGroup(1, 0, false);
 
-				it('should fire d2l-responsive-button-list-select on button click', function(done) {
-					var button = this.buttonGroup.querySelector('d2l-button-list').querySelector('.button');
-					this.buttonGroup.addEventListener('d2l-responsive-button-list-select', function(e) {
-						expect(e.detail.src).to.equal(button);
-						done();
-					});
-					button.click();
-				});
-
-				it('should fire d2l-responsive-button-list-select on menu-item click', function(done) {
+				it('button should fire d2l-responsive-button-menu-list-menu-select on menu-item click', function(done) {
 					var button = this.buttonGroup.querySelector('d2l-button-list').querySelector('.button');
 					var menuItem = this.buttonGroup.$.menu.querySelector('d2l-menu-item');
-					this.buttonGroup.addEventListener('d2l-responsive-button-list-select', function(e) {
-						expect(e.detail.src).to.equal(button);
+					button.addEventListener('d2l-responsive-button-list-menu-select', function(e) {
 						done();
 					});
 					menuItem.click();
@@ -338,20 +328,6 @@
 					expect(menuItem.text.trim()).to.equal('Test2');
 					expect(domChange).to.have.been.calledTwice;
 				});
-
-				it('should onTap on button click', function() {
-					this.template.onTap = sinon.spy();
-					var button = this.buttonGroup.querySelector('d2l-button-list').querySelector('.button');
-					button.click();
-					expect(this.template.onTap).to.have.been.calledOnce;
-				});
-
-				it('should onTap on menu-item click', function() {
-					this.template.onTap = sinon.spy();
-					var menuItem = this.buttonGroup.$.menu.querySelector('d2l-menu-item');
-					menuItem.click();
-					expect(this.template.onTap).to.have.been.calledOnce;
-				});
 			});
 
 			describe('two-button', function() {
@@ -363,39 +339,19 @@
 
 				testGroup(2, 0, false);
 
-				it('should fire d2l-responsive-button-list-select on button click (first)', function(done) {
-					var button = this.buttonGroup.querySelector('d2l-button-list').querySelector('.button');
-					this.buttonGroup.addEventListener('d2l-responsive-button-list-select', function(e) {
-						expect(e.detail.src).to.equal(button);
-						done();
-					});
-					button.click();
-				});
-
-				it('should fire d2l-responsive-button-list-select on menu-item click (first)', function(done) {
+				it('button should fire d2l-responsive-button-list-menu-select on menu-item click (first)', function(done) {
 					var button = this.buttonGroup.querySelector('d2l-button-list').querySelector('.button');
 					var menuItem = this.buttonGroup.$.menu.querySelector('d2l-menu-item');
-					this.buttonGroup.addEventListener('d2l-responsive-button-list-select', function(e) {
-						expect(e.detail.src).to.equal(button);
+					button.addEventListener('d2l-responsive-button-list-menu-select', function(e) {
 						done();
 					});
 					menuItem.click();
 				});
 
-				it('should fire d2l-responsive-button-list-select on button click (second)', function(done) {
-					var button = this.buttonGroup.querySelector('d2l-button-list').querySelectorAll('.button')[1];
-					this.buttonGroup.addEventListener('d2l-responsive-button-list-select', function(e) {
-						expect(e.detail.src).to.equal(button);
-						done();
-					});
-					button.click();
-				});
-
-				it('should fire d2l-responsive-button-list-select on menu-item click (second)', function(done) {
+				it('button should fire d2l-responsive-button-list-menu-select on menu-item click (second)', function(done) {
 					var button = this.buttonGroup.querySelector('d2l-button-list').querySelectorAll('.button')[1];
 					var menuItem = this.buttonGroup.$.menu.querySelectorAll('d2l-menu-item')[1];
-					this.buttonGroup.addEventListener('d2l-responsive-button-list-select', function(e) {
-						expect(e.detail.src).to.equal(button);
+					button.addEventListener('d2l-responsive-button-list-menu-select', function(e) {
 						done();
 					});
 					menuItem.click();

--- a/test/button-group.html
+++ b/test/button-group.html
@@ -264,7 +264,7 @@
 				it('button should fire d2l-responsive-button-menu-list-menu-select on menu-item click', function(done) {
 					var button = this.buttonGroup.querySelector('d2l-button-list').querySelector('.button');
 					var menuItem = this.buttonGroup.$.menu.querySelector('d2l-menu-item');
-					button.addEventListener('d2l-responsive-button-list-menu-select', function() {
+					button.addEventListener('d2l-button-ghost-click', function() {
 						done();
 					});
 					menuItem.click();
@@ -339,19 +339,19 @@
 
 				testGroup(2, 0, false);
 
-				it('button should fire d2l-responsive-button-list-menu-select on menu-item click (first)', function(done) {
+				it('button should fire d2l-button-ghost-click on menu-item click (first)', function(done) {
 					var button = this.buttonGroup.querySelector('d2l-button-list').querySelector('.button');
 					var menuItem = this.buttonGroup.$.menu.querySelector('d2l-menu-item');
-					button.addEventListener('d2l-responsive-button-list-menu-select', function() {
+					button.addEventListener('d2l-button-ghost-click', function() {
 						done();
 					});
 					menuItem.click();
 				});
 
-				it('button should fire d2l-responsive-button-list-menu-select on menu-item click (second)', function(done) {
+				it('button should fire d2l-button-ghost-click on menu-item click (second)', function(done) {
 					var button = this.buttonGroup.querySelector('d2l-button-list').querySelectorAll('.button')[1];
 					var menuItem = this.buttonGroup.$.menu.querySelectorAll('d2l-menu-item')[1];
-					button.addEventListener('d2l-responsive-button-list-menu-select', function() {
+					button.addEventListener('d2l-button-ghost-click', function() {
 						done();
 					});
 					menuItem.click();

--- a/test/button-group.html
+++ b/test/button-group.html
@@ -264,7 +264,7 @@
 				it('button should fire d2l-responsive-button-menu-list-menu-select on menu-item click', function(done) {
 					var button = this.buttonGroup.querySelector('d2l-button-list').querySelector('.button');
 					var menuItem = this.buttonGroup.$.menu.querySelector('d2l-menu-item');
-					button.addEventListener('d2l-responsive-button-list-menu-select', function(e) {
+					button.addEventListener('d2l-responsive-button-list-menu-select', function() {
 						done();
 					});
 					menuItem.click();
@@ -342,7 +342,7 @@
 				it('button should fire d2l-responsive-button-list-menu-select on menu-item click (first)', function(done) {
 					var button = this.buttonGroup.querySelector('d2l-button-list').querySelector('.button');
 					var menuItem = this.buttonGroup.$.menu.querySelector('d2l-menu-item');
-					button.addEventListener('d2l-responsive-button-list-menu-select', function(e) {
+					button.addEventListener('d2l-responsive-button-list-menu-select', function() {
 						done();
 					});
 					menuItem.click();
@@ -351,7 +351,7 @@
 				it('button should fire d2l-responsive-button-list-menu-select on menu-item click (second)', function(done) {
 					var button = this.buttonGroup.querySelector('d2l-button-list').querySelectorAll('.button')[1];
 					var menuItem = this.buttonGroup.$.menu.querySelectorAll('d2l-menu-item')[1];
-					button.addEventListener('d2l-responsive-button-list-menu-select', function(e) {
+					button.addEventListener('d2l-responsive-button-list-menu-select', function() {
 						done();
 					});
 					menuItem.click();


### PR DESCRIPTION
@dbatiste 
This is related to the defect on mobile devices, where Polymer "intercepts" the click event and cancels it when it does not originate from the same target area on the screen.  I tried a couple things since we last chatted - 1) altering the event so that Polymer would ignore the event - can't really modify event properties like that though  2) adding new functionality to d2l-button, something like "fireClickEvent" which would fire a click event on itself.  However, this didn't work, Polymer still seemed to interfere with it.

So this seemed to be the necessary change that will work with the LMS.  Basically a custom event is fired from the button.

There was an existing event that was fired - I don't see anything using it though and wanted to simplify things (sort of) so that only one event is fired, so I removed the other event at the same time.  

I can update the readme if the change looks fine.  There will be a corresponding PR for the LMS.