### PR TITLE
Dbatiste/force chomped shadow dom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bower_components*
 node_modules
 bower-*.json
+package-lock.json

--- a/d2l-button-group-styles.html
+++ b/d2l-button-group-styles.html
@@ -26,7 +26,7 @@
 			}
 
 			:host .d2l-button-group-container ::slotted([chomped]) {
-				display: none;
+				display: none !important;
 			}
 
 		</style>

--- a/d2l-button-group-styles.html
+++ b/d2l-button-group-styles.html
@@ -25,6 +25,9 @@
 				margin-right: 0.75rem;
 			}
 
+			/* using !important to force override.  ex. consumer has explicitly
+			specified display. note: inline styles, and shadow-dom with consumer specified
+			css will override this unless !important is specified */
 			:host .d2l-button-group-container ::slotted([chomped]) {
 				display: none !important;
 			}


### PR DESCRIPTION
This change adds `!important` for the `display` property of chomped items.  This is needed to override in cases where the client may have specified a display property with CSS that trumps our chomped selector.

This issue was noticed with Polymer 2 + shadow-DOM in the LMS.  It was not previously noticed with Polymer 1 in LMS, however it is reproducible with inline style attribute.