### PR TITLE
trimming textContent to avoid picking up newlines

### DIFF
--- a/d2l-button-group-responsive-behavior.js
+++ b/d2l-button-group-responsive-behavior.js
@@ -303,8 +303,8 @@ D2L.PolymerBehaviors.ButtonGroup.ResponsiveBehaviorImpl = {
 
 	_createMenuItem: function(item) {
 		var menuItem = document.createElement('d2l-menu-item');
-		var childText = item.firstChild && (item.firstChild.label || item.firstChild.text || item.firstChild.textContent);
-		menuItem.setAttribute('text', item.label || item.text || item.textContent || childText);
+		var childText = item.firstChild && (item.firstChild.label || item.firstChild.text || item.firstChild.textContent.trim());
+		menuItem.setAttribute('text', item.label || item.text || item.textContent.trim() || childText);
 		if (item.disabled) {
 			menuItem.setAttribute('disabled', 'disabled');
 		}
@@ -318,7 +318,7 @@ D2L.PolymerBehaviors.ButtonGroup.ResponsiveBehaviorImpl = {
 	_createMenuItemLink: function(item) {
 		var menuItem = document.createElement('d2l-menu-item-link');
 		menuItem.preventDefault = item.getAttribute('data-prevent-default');
-		menuItem.setAttribute('text', item.textContent);
+		menuItem.setAttribute('text', item.textContent.trim());
 		menuItem.setAttribute('href', item.href);
 		if (item.target) {
 			menuItem.setAttribute('target', item.target);


### PR DESCRIPTION
When the item contains newlines, its `textContent` was being chosen instead of looking elsewhere for text. For example, this tripped up the code:

```html
<div>
    <d2l-button-subtle text="foo"></d2l-button-subtle>
</div>
```

That resulted in the `<div>`'s `textContent` (just a newline) being picked for the item's text.