### PR TITLE
adding ability to use a more opener

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,14 @@
 # d2l-button-group
-[![Published on webcomponents.org](https://img.shields.io/badge/webcomponents.org-published-blue.svg)](https://www.webcomponents.org/element/BrightspaceUI/button-group)
-[![Bower version][bower-image]][bower-url]
 [![Build status][ci-image]][ci-url]
 
 [Polymer](https://www.polymer-project.org)-based web component for responsive button groups, overflowing buttons into a dropdown menu based on configuration and space available.
 
 For further information on this and other components, refer to [The Brightspace UI Guide](https://github.com/BrightspaceUI/guide/wiki).
 
-## Installation
-
-`d2l-button-group` can be installed from [Bower][bower-url]:
-```shell
-bower install d2l-button-group
-```
-
 ## Usage
-
-Include the [webcomponents.js](http://webcomponents.org/polyfills/) "lite" polyfill (for browsers who don't natively support web components), then import `d2l-button-group.html` or `d2l-action-button-group.html`:
-
-```html
-<head>
-  <script src="../webcomponentsjs/webcomponents-lite.js"></script>
-  <link rel="import" href="../d2l-button-group/d2l-button-group.html">
-</head>
-```
 
 A `<d2l-button-group>` custom element can be used in your application to define a responsive group of buttons and dropdown buttons.  The `min-to-show` and `max-to-show` attributes can be used to configure how many buttons will be displayed.  By default, a minimum of zero buttons will be displayed, and all buttons will be displayed if space is available.
 
-<!---
-```
-<custom-element-demo>
-  <template>
-    <script src="../webcomponentsjs/webcomponents-lite.js"></script>
-    <link rel="import" href="../d2l-typography/d2l-typography.html">
-    <link rel="import" href="../d2l-button/d2l-button.html">
-    <link rel="import" href="../d2l-dropdown/d2l-dropdown-button.html">
-    <link rel="import" href="../d2l-dropdown/d2l-dropdown-menu.html">
-    <link rel="import" href="../d2l-menu/d2l-menu.html">
-    <link rel="import" href="../d2l-menu/d2l-menu-item.html">
-    <link rel="import" href="d2l-button-group.html">
-    <custom-style include="d2l-typography">
-      <style is="custom-style" include="d2l-typography"></style>
-    </custom-style>
-    <style>
-      html {
-        font-size: 20px;
-      }
-      d2l-button-group,
-      d2l-action-button-group {
-        color: var(--d2l-color-ferrite);
-        font-family: 'Lato', 'Lucida Sans Unicode', 'Lucida Grande', sans-serif;
-        letter-spacing: 0.01rem;
-        font-size: 0.95rem;
-        font-weight: 400;
-        line-height: 1.4rem;
-      }
-    </style>
-    <script>
-      document.body.addEventListener('d2l-dropdown-open', function() { document.body.style.height = '200px'; });
-    </script>
-    <next-code-block></next-code-block>
-  </template>
-</custom-element-demo>
-```
--->
 ```html
 <d2l-button-group min-to-show="1" max-to-show="3">
 	<d2l-button primary>New</d2l-button>
@@ -87,46 +32,6 @@ A `<d2l-button-group>` custom element can be used in your application to define 
 
 A `<d2l-action-button-group>` custom element can be used in your application to define a responsive group of actions with the same behavior and attributes as described for `<d2l-button-group>`.  Typically these will include one or more subtle buttons (`<d2l-button-subtle>`) as shown.
 
-<!---
-```
-<custom-element-demo>
-  <template>
-    <script src="../webcomponentsjs/webcomponents-lite.js"></script>
-    <link rel="import" href="../d2l-typography/d2l-typography.html">
-    <link rel="import" href="../d2l-button/d2l-button.html">
-    <link rel="import" href="../d2l-button/d2l-button-subtle.html">
-    <link rel="import" href="../d2l-dropdown/d2l-dropdown-button.html">
-    <link rel="import" href="../d2l-dropdown/d2l-dropdown-menu.html">
-    <link rel="import" href="../d2l-menu/d2l-menu.html">
-    <link rel="import" href="../d2l-menu/d2l-menu-item.html">
-    <link rel="import" href="../d2l-icons/tier1-icons.html">
-    <link rel="import" href="d2l-button-group.html">
-    <link rel="import" href="d2l-action-button-group.html">
-    <custom-style include="d2l-typography">
-      <style is="custom-style" include="d2l-typography"></style>
-    </custom-style>
-    <style>
-      html {
-        font-size: 20px;
-      }
-      d2l-button-group,
-      d2l-action-button-group {
-        color: var(--d2l-color-ferrite);
-        font-family: 'Lato', 'Lucida Sans Unicode', 'Lucida Grande', sans-serif;
-        letter-spacing: 0.01rem;
-        font-size: 0.95rem;
-        font-weight: 400;
-        line-height: 1.4rem;
-      }
-    </style>
-    <script>
-      document.body.addEventListener('d2l-dropdown-open', function() { document.body.style.height = '200px'; });
-    </script>
-    <next-code-block></next-code-block>
-  </template>
-</custom-element-demo>
-```
--->
 ```html
 <d2l-action-button-group min-to-show="1" max-to-show="5">
 	<d2l-button-subtle icon="d2l-tier1:add" text="Add"></d2l-button-subtle>
@@ -138,6 +43,8 @@ A `<d2l-action-button-group>` custom element can be used in your application to 
 	<d2l-button-subtle icon="d2l-tier1:refresh" text="Refresh"></d2l-button-subtle>
 </d2l-action-button-group>
 ```
+
+To use a `<d2l-dropdown-more>` "..." opener, set the `opener-type` attribute to `"more"`.
 
 ## Developing, Testing and Contributing
 
@@ -173,8 +80,6 @@ To lint AND run local unit tests:
 npm test
 ```
 
-[bower-url]: http://bower.io/search/?q=d2l-button-group
-[bower-image]: https://badge.fury.io/bo/d2l-button-group.svg
 [ci-url]: https://travis-ci.com/BrightspaceUI/button-group
 [ci-image]: https://travis-ci.com/BrightspaceUI/button-group.svg?branch=master
 

--- a/d2l-action-button-group.js
+++ b/d2l-action-button-group.js
@@ -1,78 +1,90 @@
 /**
 `d2l-action-button-group`
 Polymer-based web component to responsively encapsulate a group of actions buttons
-
 @demo demo/action-button-group.html Subtle Buttons
 */
-/*
-  FIXME(polymer-modulizer): the above comments were extracted
-  from HTML and may be out of place here. Review them and
-  then delete this comment!
-*/
-import '@polymer/polymer/polymer-legacy.js';
-
 import 'd2l-button/d2l-button-subtle.js';
 import 'd2l-colors/d2l-colors.js';
 import 'd2l-dropdown/d2l-dropdown.js';
 import 'd2l-dropdown/d2l-dropdown-menu.js';
+import 'd2l-dropdown/d2l-dropdown-more.js';
 import 'd2l-icons/d2l-icon.js';
-import 'd2l-icons/tier1-icons.js';
 import 'd2l-menu/d2l-menu.js';
 import 'd2l-offscreen/d2l-offscreen-shared-styles.js';
 import './d2l-button-group-responsive-behavior.js';
 import './d2l-button-group-styles.js';
 import './localize-behavior.js';
-import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
-const $_documentContainer = document.createElement('template');
+import '@polymer/polymer/lib/elements/dom-if.js';
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 
-$_documentContainer.innerHTML = `<dom-module id="d2l-action-button-group">
-	<template strip-whitespace="">
-		<style include="d2l-button-group-styles d2l-offscreen-shared-styles">
+class ActionButtonGroup extends mixinBehaviors([
+	D2L.PolymerBehaviors.ButtonGroup.ResponsiveBehavior,
+	D2L.PolymerBehaviors.ButtonGroup.LocalizeBehavior
+], PolymerElement) {
 
-			.d2l-dropdown-opener-text {
-				margin-right: 0.3rem;
-				vertical-align: middle;
+	static get properties() {
+		return {
+			openerType: {
+				type: String,
+				value: 'button'
 			}
+		};
+	}
 
-			.d2l-dropdown-opener-text,
-			d2l-icon {
-				color: var(--d2l-color-celestine);
-			}
+	static get template() {
+		return html`
+			<style include="d2l-button-group-styles d2l-offscreen-shared-styles">
 
-			:host(:dir(rtl)) .d2l-dropdown-opener-text {
-				margin-left: 0.3rem;
-				margin-right: 0;
-			}
+				.d2l-dropdown-opener-text {
+					margin-right: 0.3rem;
+					vertical-align: middle;
+				}
 
-			:host([mini]) .d2l-dropdown-opener-text {
-				@apply --d2l-offscreen;
-			}
+				.d2l-dropdown-opener-text,
+				d2l-icon {
+					color: var(--d2l-color-celestine);
+				}
 
-		</style>
-		<div class="d2l-button-group-container">
-			<slot id="buttons"></slot>
-			<d2l-dropdown class="d2l-overflow-dropdown">
-				<d2l-button-subtle class="d2l-dropdown-opener">
-					<span class="d2l-dropdown-opener-text">[[localize('moreActions')]]</span>
-					<d2l-icon icon="[[icon]]"></d2l-icon>
-				</d2l-button-subtle>
-				<d2l-dropdown-menu render-content="">
-					<d2l-menu id="overflowMenu" label="[[localize('more')]]">
-					</d2l-menu>
-				</d2l-dropdown-menu>
-			</d2l-dropdown>
-		</div>
-	</template>
-	
-</dom-module>`;
+				:host(:dir(rtl)) .d2l-dropdown-opener-text {
+					margin-left: 0.3rem;
+					margin-right: 0;
+				}
 
-document.head.appendChild($_documentContainer.content);
-Polymer({
-	is: 'd2l-action-button-group',
+				:host([mini]) .d2l-dropdown-opener-text {
+					@apply --d2l-offscreen;
+				}
 
-	behaviors: [
-		D2L.PolymerBehaviors.ButtonGroup.ResponsiveBehavior,
-		D2L.PolymerBehaviors.ButtonGroup.LocalizeBehavior
-	]
+			</style>
+			<div class="d2l-button-group-container">
+				<slot id="buttons"></slot>
+				<template is="dom-if" if="{{!_isOpenerMore(openerType)}}">
+					<d2l-dropdown class="d2l-overflow-dropdown">
+						<d2l-button-subtle class="d2l-dropdown-opener">
+							<span class="d2l-dropdown-opener-text">[[localize('moreActions')]]</span>
+							<d2l-icon icon="[[icon]]"></d2l-icon>
+						</d2l-button-subtle>
+						<d2l-dropdown-menu>
+							<d2l-menu id="overflowMenu" label="[[localize('more')]]">
+							</d2l-menu>
+						</d2l-dropdown-menu>
+					</d2l-dropdown>
+				</template>
+				<template is="dom-if" if="{{_isOpenerMore(openerType)}}">
+					<d2l-dropdown-more class="d2l-overflow-dropdown" text="[[localize('moreActions')]]">
+						<d2l-dropdown-menu>
+							<d2l-menu id="overflowMenu" label="[[localize('more')]]">
+							</d2l-menu>
+						</d2l-dropdown-menu>
+					</d2l-dropdown>
+				</template>
+			</div>
+		`;
+	}
 
-});
+	_isOpenerMore(openerType) {
+		return openerType === 'more';
+	}
+
+}
+customElements.define('d2l-action-button-group', ActionButtonGroup);

--- a/d2l-button-group-responsive-behavior.js
+++ b/d2l-button-group-responsive-behavior.js
@@ -374,7 +374,7 @@ D2L.PolymerBehaviors.ButtonGroup.ResponsiveBehaviorImpl = {
 		fastdom.measure(function() {
 
 			this._container = dom(this.root).querySelector('.d2l-button-group-container');
-			this._overflowMenu = dom(this.root).querySelector('d2l-dropdown.d2l-overflow-dropdown');
+			this._overflowMenu = dom(this.root).querySelector('.d2l-overflow-dropdown');
 
 			var items = this._getItems();
 			if (this.autoShow) {

--- a/demo/action-button-group.html
+++ b/demo/action-button-group.html
@@ -56,7 +56,7 @@ const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<div class="vertical-section-container centered">
 
-			<h3>Image Actions</h3>
+			<h3>Image Actions ("button" opener)</h3>
 			<demo-snippet>
 				<template>
 					<d2l-action-button-group min-to-show="1" max-to-show="5">
@@ -92,7 +92,42 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 					</d2l-action-button-group>
 				</template>
 			</demo-snippet>
-
+			<h3>Image Actions ("more" opener)</h3>
+			<demo-snippet>
+				<template>
+					<d2l-action-button-group min-to-show="1" max-to-show="5" opener-type="more">
+						<d2l-button-subtle icon="d2l-tier1:add" text="Add"></d2l-button-subtle>
+						<d2l-button-subtle icon="d2l-tier1:copy" text="Copy"></d2l-button-subtle>
+						<d2l-dropdown-button-subtle text="Explore Topics">
+							<d2l-dropdown-menu>
+								<d2l-menu label="Astronomy">
+									<d2l-menu-item text="Introduction"></d2l-menu-item>
+									<d2l-menu-item text="Searching for the Heavens "></d2l-menu-item>
+									<d2l-menu-item text="The Solar System"></d2l-menu-item>
+									<d2l-menu-item text="Stars &amp; Galaxies"></d2l-menu-item>
+									<d2l-menu-item text="The Night Sky"></d2l-menu-item>
+									<d2l-menu-item text="The Universe"></d2l-menu-item>
+								</d2l-menu>
+							</d2l-dropdown-menu>
+						</d2l-dropdown-button-subtle>
+						<d2l-button-subtle icon="d2l-tier1:pin-filled" text="Pin"></d2l-button-subtle>
+						<d2l-button-subtle icon="d2l-tier1:print" text="Print"></d2l-button-subtle>
+						<d2l-button-subtle icon="d2l-tier1:delete" text="Delete"></d2l-button-subtle>
+						<d2l-button-subtle icon="d2l-tier1:gear" text="Settings"></d2l-button-subtle>
+						<d2l-dropdown-button-subtle text="Types of Dogs">
+							<d2l-dropdown-menu>
+								<d2l-menu label="Dogs">
+									<d2l-menu-item text="Dachshund"></d2l-menu-item>
+									<d2l-menu-item text="Golden Retriever"></d2l-menu-item>
+									<d2l-menu-item text="Sheltie"></d2l-menu-item>
+								</d2l-menu>
+							</d2l-dropdown-menu>
+						</d2l-dropdown-button-subtle>
+						<d2l-button-subtle icon="d2l-tier1:refresh" text="Refresh"></d2l-button-subtle>
+						<div class="d2l-button-group-custom-item"><d2l-button-subtle icon="d2l-tier1:refresh" text="Custom Refresh"></d2l-button-subtle></div>
+					</d2l-action-button-group>
+				</template>
+			</demo-snippet>
 		</div>`;
 
 document.body.appendChild($_documentContainer.content);


### PR DESCRIPTION
@MykolaGalian wanted the ability to use a "..." more opener instead of a subtle button with "More Actions" -- which makes sense since that's what we use in the LMS.

This ends up looking like this:
![Screen Shot 2020-10-22 at 1 55 59 PM](https://user-images.githubusercontent.com/5491151/96911141-6e096680-146e-11eb-866c-a8902c46818f.png)

I converted the one class over to Polymer 3 while I was in here as it made the `dom-if` template easier to use.