### PR TITLE
switch to shared secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,5 @@ jobs:
       - name: Unit Tests (SauceLabs)
         run: npm run test:polymer:sauce
         env:
-          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY_DESIRE2LEARN }}
           SAUCE_USERNAME: Desire2Learn


### PR DESCRIPTION
I've moved the "Desire2Learn" standard Sauce secret to be shared in the organization, so repos who want to use it don't need to encrypt anything themselves.